### PR TITLE
Add missing fields to `react` package.json

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,5 +26,11 @@
   },
   "dependencies": {
     "react": "^18.2.0"
-  }
+  },
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/token-icons/monorepo",
+    "directory": "packages/react"
+  },
 }


### PR DESCRIPTION
- `sideEffects: false` is a customary field for treeshaking in bundlers
  - https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

- `repository` allows the user to go from npm to there repo (they render a link to GitHub)